### PR TITLE
Sync changes: Emitting single span for not sampled traces, and regulating cache delay

### DIFF
--- a/internal/ptraceutil/go.mod
+++ b/internal/ptraceutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/atlassian-labs/atlassian-sampling-processor/internal/ptraceutil
 
-go 1.23.4
+go 1.23.5
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.115.0

--- a/pkg/processor/atlassiansamplingprocessor/DESIGN.md
+++ b/pkg/processor/atlassiansamplingprocessor/DESIGN.md
@@ -41,7 +41,7 @@ code significantly and potentially lead to bugs, as experienced in the upstream 
 
 This is, of course, a trade-off. The processing throughput is limited by the capacity of a single goroutine, 
 creating a potential bottleneck. This can be alleviated by deploying more instances of the processor with reduced 
-memory allocation per instance (e.g., more pods, each with less memory). If the bottleneck becomes a significant issue, 
+memory allocation per instance (e.g., more nodes, each with less memory). If the bottleneck becomes a significant issue, 
 a future enhancement could involve sharding the processor. This would involve splitting the processing workload by trace 
 ID and maintaining separate caches and states for each shard.
 
@@ -107,7 +107,8 @@ they can only access cached metadata from the cache. This restriction is in plac
 1. **Cache Compression:** It allows for the compression of spans within the cache. We are guaranteed that a compressed 
 blob is decompressed at most once, which occurs in the case it is sampled and transmitted. 
 Restricting the reading of cached spans allows for this optimisation.
-1.**Performance Efficiency:** It ensures that policy evaluation remains efficient, adhering to O(n) complexity, 
+
+2. **Performance Efficiency:** It ensures that policy evaluation remains efficient, adhering to O(n) complexity, 
 where n represents the number of spans in the current arriving batch. This prevents the policies from becoming slow.
 
 ## Caches

--- a/pkg/processor/atlassiansamplingprocessor/README.md
+++ b/pkg/processor/atlassiansamplingprocessor/README.md
@@ -44,7 +44,7 @@ The `primary_cache_size` value should be greater than 0, and should be set to a 
 `processor_atlassian_sampling_trace_eviction_time` metric to tune how long you would like your traces to stay pending
 in memory before being considered not-sampled.
 
-The primary cache size is initially set to 80% of the `primary_cache_size` value.
+The primary cache size is initially set to 60% of the `primary_cache_size` value.
 It is automatically adjusted depending on heap memory usage at runtime, but will not exceed the `primary_cache_size` value.
 
 ### `secondary_cache_size`
@@ -102,6 +102,9 @@ The order of the policies is important, as the first one that matches a non-pend
 used as the final decision.
 
 Policies include a `name`, `type`, and then further configuration depending on what the `type` was.
+
+`emit_single_span_for_not_sampled` is an optional field that can be set to `true` for a policy. If set, the processor will emit a single span for a trace that is not sampled, instead of dropping the trace entirely. 
+This span will have the same trace ID as the original trace. The span will have the name `TRACE NOT SAMPLED`, with policy name in its attribute.
 
 Current supported policy types are: 
 

--- a/pkg/processor/atlassiansamplingprocessor/config.go
+++ b/pkg/processor/atlassiansamplingprocessor/config.go
@@ -2,6 +2,7 @@ package atlassiansamplingprocessor // import "github.com/atlassian-labs/atlassia
 
 import (
 	"errors"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.uber.org/multierr"
@@ -16,6 +17,11 @@ type Config struct {
 	// If set, the processor may adjust cache sizes dynamically in order to keep within the target.
 	// A good starting point to set this is about 75% of overall memory resource allocation.
 	TargetHeapBytes uint64 `mapstructure:"target_heap_bytes"`
+
+	// RegulateCacheDelay is the amount of time after which the processor starts regulating cache sizes based on the set TargetHeapBytes (if specified).
+	// It is optional and defaults to 0s.
+	// This can be used to avoid regulating cache sizes on an initial empty cache, as it can cause unnecessary cache size adjustments and high memory usage.
+	RegulateCacheDelay time.Duration `mapstructure:"regulate_cache_delay"`
 
 	// PrimaryCacheSize sets the initial and maximum size of the primary cache that holds non-low priority traces.
 	PrimaryCacheSize int `mapstructure:"primary_cache_size"`

--- a/pkg/processor/atlassiansamplingprocessor/config_policy.go
+++ b/pkg/processor/atlassiansamplingprocessor/config_policy.go
@@ -31,6 +31,9 @@ type SharedPolicyConfig struct {
 	Name string `mapstructure:"name"`
 	// Type of the policy this will be used to match the proper configuration of the policy.
 	Type PolicyType `mapstructure:"type"`
+	// EmitSingleSpanForNotSampled enabled to emit a single span with same trace ID as the one that was dropped.
+	// So when people search for it, it comes up with “TRACE NOT SAMPLED” and then the sampling policy name attached as an attribute.
+	EmitSingleSpanForNotSampled bool `mapstructure:"emit_single_span_for_not_sampled"`
 	// Configs for probabilistic sampling policy evaluator.
 	ProbabilisticConfig `mapstructure:"probabilistic"`
 	// Configs for span count filter sampling policy evaluator.

--- a/pkg/processor/atlassiansamplingprocessor/config_policy_test.go
+++ b/pkg/processor/atlassiansamplingprocessor/config_policy_test.go
@@ -47,6 +47,7 @@ func TestPolicyCreationFromConfig(t *testing.T) {
 	assert.Equal(t, RemoteProbabilistic, policies[8].policyType)
 	assert.Equal(t, "test-policy-10", policies[9].name)
 	assert.Equal(t, Downgrader, policies[9].policyType)
+	assert.True(t, policies[9].emitSingleSpanForNotSampled)
 
 	assert.Equal(t, 10, len(policies), "wrong number of assertions")
 }

--- a/pkg/processor/atlassiansamplingprocessor/config_test.go
+++ b/pkg/processor/atlassiansamplingprocessor/config_test.go
@@ -9,6 +9,7 @@ package atlassiansamplingprocessor
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,12 +34,16 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, sub.Unmarshal(cfg))
 
+	delay, err := time.ParseDuration("5m")
+	require.NoError(t, err)
+
 	assert.Equal(t,
 		cfg,
 		&Config{
 			PrimaryCacheSize:   1000,
 			SecondaryCacheSize: 100,
 			TargetHeapBytes:    100_000_000,
+			RegulateCacheDelay: delay,
 			DecisionCacheCfg:   DecisionCacheCfg{SampledCacheSize: 1000, NonSampledCacheSize: 10000},
 			CompressionEnabled: true,
 			PolicyConfig: []PolicyConfig{
@@ -151,8 +156,9 @@ func TestLoadConfig(t *testing.T) {
 				},
 				{
 					SharedPolicyConfig: SharedPolicyConfig{
-						Name: "test-policy-10",
-						Type: "downgrader",
+						Name:                        "test-policy-10",
+						Type:                        "downgrader",
+						EmitSingleSpanForNotSampled: true,
 					},
 					DowngraderConfig: DowngraderConfig{
 						DowngradeTo: "NotSampled",

--- a/pkg/processor/atlassiansamplingprocessor/go.mod
+++ b/pkg/processor/atlassiansamplingprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/atlassian-labs/atlassian-sampling-processor/pkg/processor/atlassiansamplingprocessor
 
-go 1.23.4
+go 1.23.5
 
 require (
 	github.com/atlassian-labs/atlassian-sampling-processor/internal/ptraceutil v0.7.6

--- a/pkg/processor/atlassiansamplingprocessor/policy.go
+++ b/pkg/processor/atlassiansamplingprocessor/policy.go
@@ -16,6 +16,8 @@ type policy struct {
 	name string
 	// type is used to identify this policy instance's policyType
 	policyType PolicyType
+	// emitSingleSpanForNotSampled is used to determine if a single span should be emitted for a trace that is not sampled.
+	emitSingleSpanForNotSampled bool
 	// evaluator that decides if a trace is sampled or not by this policy instance.
 	evaluator evaluators.PolicyEvaluator
 	// attribute to use in the telemetry to denote the policy.
@@ -38,10 +40,11 @@ func newPolicies(cfg []PolicyConfig, set component.TelemetrySettings) ([]*policy
 			return nil, err
 		}
 		p := &policy{
-			name:       policyCfg.Name,
-			policyType: policyCfg.Type,
-			evaluator:  eval,
-			attribute:  metric.WithAttributes(attribute.String("policy", policyCfg.Name)),
+			name:                        policyCfg.Name,
+			policyType:                  policyCfg.Type,
+			emitSingleSpanForNotSampled: policyCfg.EmitSingleSpanForNotSampled,
+			evaluator:                   eval,
+			attribute:                   metric.WithAttributes(attribute.String("policy", policyCfg.Name)),
 		}
 		pols[i] = p
 	}

--- a/pkg/processor/atlassiansamplingprocessor/testdata/atlassian_sampling_test_cfg.yml
+++ b/pkg/processor/atlassiansamplingprocessor/testdata/atlassian_sampling_test_cfg.yml
@@ -2,6 +2,7 @@ atlassian_sampling:
   primary_cache_size: 1000
   secondary_cache_size: 100
   target_heap_bytes: 100_000_000 # 100 MB
+  regulate_cache_delay: 5m
   decision_cache:
     sampled_cache_size: 1000
     non_sampled_cache_size: 10000
@@ -88,6 +89,7 @@ atlassian_sampling:
       {
         name: test-policy-10,
         type: downgrader,
+        emit_single_span_for_not_sampled: true,
         downgrader: {
           downgrade_to: "NotSampled",
           sub_policy: {


### PR DESCRIPTION
Changes include: 
- regulating cache delay option which specifies the amount of time after which the processor starts regulating cache sizes.  This can be used to avoid regulating cache sizes on an initial empty cache, as it can cause unnecessary cache size adjustments and high memory usage. More in docs.
- Emitting span for not sampled trace. You can now specify on specific policies to emit a single span in place of the trace. This is useful if someone goes searching for a dropped trace in the system, it will tell them why it's dropped because a span appears with the policy. 